### PR TITLE
Lock version of oauth2 client to before they made a breaking change.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "league/oauth2-client": "~2.2"
+        "league/oauth2-client": "2.2.1"
     },
     "require-dev": {
         "mockery/mockery": "~0.9",


### PR DESCRIPTION
oauth-client changed their api from under us, so lock to the older version so we can patch 1.0