### PR TITLE
Change exception response

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "league/oauth2-client": "~2.2"
+        "league/oauth2-client": "2.4.*"
     },
     "require-dev": {
         "mockery/mockery": "~0.9",

--- a/src/Provider/Withings.php
+++ b/src/Provider/Withings.php
@@ -108,7 +108,7 @@ class Withings extends AbstractProvider
             throw new IdentityProviderException(
                 $errorMessage,
                 $errorCode,
-                $response
+		$data
             );
         }
     }
@@ -155,7 +155,7 @@ class Withings extends AbstractProvider
      */
     public function revoke(AccessToken $accessToken)
     {
-        $options = $this->getAccessTokenOptions([]);
+	$options = $this->optionProvider->getAccessTokenOptions($this->getAccessTokenMethod(), []);
         $uri = $this->appendQuery(
             self::BASE_WITHINGS_API_URL.'/notify?action=revoke',
             $this->buildQueryString(['token' => $accessToken->getToken()])

--- a/src/Provider/Withings.php
+++ b/src/Provider/Withings.php
@@ -108,7 +108,7 @@ class Withings extends AbstractProvider
             throw new IdentityProviderException(
                 $errorMessage,
                 $errorCode,
-		$data
+                $data
             );
         }
     }
@@ -155,7 +155,7 @@ class Withings extends AbstractProvider
      */
     public function revoke(AccessToken $accessToken)
     {
-	$options = $this->optionProvider->getAccessTokenOptions($this->getAccessTokenMethod(), []);
+        $options = $this->optionProvider->getAccessTokenOptions($this->getAccessTokenMethod(), []);
         $uri = $this->appendQuery(
             self::BASE_WITHINGS_API_URL.'/notify?action=revoke',
             $this->buildQueryString(['token' => $accessToken->getToken()])

--- a/test/src/Provider/WithingsTest.php
+++ b/test/src/Provider/WithingsTest.php
@@ -136,7 +136,7 @@ RESPONSE;
     public function testParsedResponseFailure()
     {
         // When the API responds with an error, we throw an exception
-        $this->expectException(\League\OAuth2\Client\Provider\Exception\IdentityProviderException::class);
+        // $this->expectException(\League\OAuth2\Client\Provider\Exception\IdentityProviderException::class);
 
         $request = Mockery::mock(\Psr\Http\Message\RequestInterface::class);
 
@@ -148,7 +148,18 @@ RESPONSE;
         $client->shouldReceive('send')->times(1)->andReturn($response);
         $this->provider->setHttpClient($client);
 
-        $this->provider->getParsedResponse($request);
+        try {
+            $this->provider->getParsedResponse($request);
+            $this->fail('An exception should have been thrown');
+        } catch (\League\OAuth2\Client\Provider\Exception\IdentityProviderException $e) {
+            $this->assertEquals('Invalid params', $e->getMessage());
+            $this->assertEquals(503, $e->getCode());
+            // make sure response body is the parsed body
+            $body = $e->getResponseBody();
+            $this->assertTrue(is_array($body));
+            $this->assertEquals(503, $body['status']);
+            $this->assertEquals('Invalid params', $body['error']);
+        }
     }
 
     public function testCreateResourceOwner()


### PR DESCRIPTION
Two changes in this PR:

1. update our revoke code to match the change in oauth-client 2.4
2. update checkResponse to use the parsed request body when it throws an IdentityProviderException instead of the PSR7 Response. This seems to match the type hints and AbstractProvider implementation.

This should be a major version bump.